### PR TITLE
PR for amplitude to db transforms

### DIFF
--- a/lib/torchaudio.rb
+++ b/lib/torchaudio.rb
@@ -20,6 +20,7 @@ require "torchaudio/transforms/mel_spectrogram"
 require "torchaudio/transforms/mu_law_encoding"
 require "torchaudio/transforms/mu_law_decoding"
 require "torchaudio/transforms/spectrogram"
+require "torchaudio/transforms/amplitude_to_db"
 require "torchaudio/version"
 
 module TorchAudio

--- a/lib/torchaudio/functional.rb
+++ b/lib/torchaudio/functional.rb
@@ -227,6 +227,19 @@ module TorchAudio
         output
       end
 
+      def amplitude_to_DB(amp, multiplier, amin, db_multiplier, top_db = nil)
+        db = Torch.log10(Torch.clamp(amp, min: amin)) * multiplier
+        db -= multiplier * db_multiplier
+
+        db = db.clamp(min: db.max.item - top_db) if top_db
+
+        db
+      end
+
+      def DB_to_amplitude(db, ref, power)
+        Torch.pow(Torch.pow(10.0, db * 0.1), power) * ref
+      end
+
       private
 
       def _apply_probability_distribution(waveform, density_function: "TPDF")

--- a/lib/torchaudio/functional.rb
+++ b/lib/torchaudio/functional.rb
@@ -227,7 +227,7 @@ module TorchAudio
         output
       end
 
-      def amplitude_to_DB(amp, multiplier, amin, db_multiplier, top_db = nil)
+      def amplitude_to_DB(amp, multiplier, amin, db_multiplier, top_db: nil)
         db = Torch.log10(Torch.clamp(amp, min: amin)) * multiplier
         db -= multiplier * db_multiplier
 

--- a/lib/torchaudio/transforms/amplitude_to_db.rb
+++ b/lib/torchaudio/transforms/amplitude_to_db.rb
@@ -6,7 +6,7 @@ module TorchAudio
         
         @stype = stype
         
-        raise ArgumentError, 'top_db must be a positive numerical' if top_db and !(0.0..).include?(top_db)
+        raise ArgumentError, 'top_db must be a positive numerical' if top_db and top_db.negative?
         
         @top_db = top_db
         @multiplier = stype == :power ? 10.0 : 20.0

--- a/lib/torchaudio/transforms/amplitude_to_db.rb
+++ b/lib/torchaudio/transforms/amplitude_to_db.rb
@@ -1,7 +1,7 @@
 module TorchAudio
   module Transforms
     class AmplitudeToDB < Torch::NN::Module
-      def initialize stype: :power, top_db: nil
+      def initialize(stype: :power, top_db: nil)
         super()
         
         @stype = stype
@@ -15,7 +15,7 @@ module TorchAudio
         @db_multiplier = Math.log10([@amin, @ref_value].max)
       end
 
-      def forward amplitude_spectrogram
+      def forward(amplitude_spectrogram)
         F.amplitude_to_DB(
           amplitude_spectrogram, 
           @multiplier, @amin, @db_multiplier, @top_db

--- a/lib/torchaudio/transforms/amplitude_to_db.rb
+++ b/lib/torchaudio/transforms/amplitude_to_db.rb
@@ -1,0 +1,26 @@
+module TorchAudio
+  module Transforms
+    class AmplitudeToDB < Torch::NN::Module
+      def initialize stype: :power, top_db: nil
+        super()
+        
+        @stype = stype
+        
+        raise ArgumentError, 'top_db must be a positive numerical' if top_db and !(0.0..).include?(top_db)
+        
+        @top_db = top_db
+        @multiplier = stype == :power ? 10.0 : 20.0
+        @amin = 1e-10
+        @ref_value = 1.0
+        @db_multiplier = Math.log10([@amin, @ref_value].max)
+      end
+
+      def forward amplitude_spectrogram
+        F.amplitude_to_DB(
+          amplitude_spectrogram, 
+          @multiplier, @amin, @db_multiplier, @top_db
+        )
+      end
+    end
+  end
+end

--- a/lib/torchaudio/transforms/amplitude_to_db.rb
+++ b/lib/torchaudio/transforms/amplitude_to_db.rb
@@ -18,7 +18,8 @@ module TorchAudio
       def forward(amplitude_spectrogram)
         F.amplitude_to_DB(
           amplitude_spectrogram, 
-          @multiplier, @amin, @db_multiplier, @top_db
+          @multiplier, @amin, @db_multiplier, 
+          top_db: @top_db
         )
       end
     end

--- a/test/transforms_test.rb
+++ b/test/transforms_test.rb
@@ -16,6 +16,15 @@ class TransformsTest < Minitest::Test
     expected = [0, 0, 0, 0, 0]
     assert_elements_in_delta expected, transformed[0][0][0..4].to_a
   end
+  
+  def test_amplitude_to_db
+    waveform, sample_rate = TorchAudio.load(audio_path)
+    transformed = TorchAudio::Transforms::MelSpectrogram.new(sample_rate: sample_rate).call(waveform)
+    assert_equal [1, 128, 255], transformed.size
+    db = TorchAudio::Transforms::AmplitudeToDB.new(top_db: 80.0).call transformed
+    expected = [-53.64425277709961, -35.834075927734375, -39.889862060546875, -30.29456901550293, -38.77671432495117]
+    assert_elements_in_delta expected, db[0][0][0..4].to_a
+  end
 
   def test_mu_law_encoding
     waveform, sample_rate = TorchAudio.load(audio_path)

--- a/test/transforms_test.rb
+++ b/test/transforms_test.rb
@@ -11,9 +11,9 @@ class TransformsTest < Minitest::Test
 
   def test_melspectrogram
     waveform, sample_rate = TorchAudio.load(audio_path)
-    transformed = TorchAudio::Transforms::MelSpectrogram.new.call(waveform)
+    transformed = TorchAudio::Transforms::MelSpectrogram.new(sample_rate: sample_rate).call(waveform)
     assert_equal [1, 128, 255], transformed.size
-    expected = [0, 0, 0, 0, 0]
+    expected = [4.320904736232478e-06, 0.00026097119553014636, 0.00010256850509904325, 0.0009344223653897643, 0.00013253440556582063]
     assert_elements_in_delta expected, transformed[0][0][0..4].to_a
   end
   


### PR DESCRIPTION
During tests I noticed the melspec test was not using actual sample rate of test file which is 8000 instead of default 16000. So there's a commit with the fix for that.